### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "dist/cjs/sdk.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/sdk.js",
       "require": "./dist/cjs/sdk.js"
     },


### PR DESCRIPTION
fix type export for latest node versions

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR is to fix the type export issue with the latest versions of node. For example, this error being thrown in a new Vite react project: 

![image](https://github.com/appwrite/sdk-for-web/assets/32952542/205840ba-bf10-404d-bf44-f42a871f16e2)


## Test Plan

This is a package.json change, testing includes using the SDK in a project with a newer node version.

## Related PRs and Issues

[An issue on the parent repo](https://github.com/appwrite/appwrite/issues/5706)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes