### PR TITLE
API version placeholder `1.5.x` in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Appwrite Web SDK
 
 ![License](https://img.shields.io/github/license/appwrite/sdk-for-web.svg?style=flat-square)
-![Version](https://img.shields.io/badge/api%20version-1.5.0-blue.svg?style=flat-square)
+![Version](https://img.shields.io/badge/api%20version-1.5.x-blue.svg?style=flat-square)
 [![Build Status](https://img.shields.io/travis/com/appwrite/sdk-generator?style=flat-square)](https://travis-ci.com/appwrite/sdk-generator)
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR updates the API version in the README from 1.5.0 to 1.5.x to reflect the current version being used (1.5.4). This change aligns with semantic versioning practices, ensuring that only the major and minor version numbers are specified while leaving the patch version flexible.

## Test Plan

1. Verify that the README file has been updated to reflect the API version as 1.5.x.
2. Confirm that the change does not introduce any functional differences in the API documentation.
3. Check for any broken links or formatting issues caused by the update.

## Related PRs and Issues

No related PRs or issues at this time.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
