### PR TITLE
fix(web): credentials include

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { Client, Account } from "appwrite";
 To install with a CDN (content delivery network) add the following scripts to the bottom of your <body> tag, but before you use any Appwrite services:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/appwrite@16.0.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/appwrite@16.0.2"></script>
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appwrite",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstract and simplify complex and repetitive development tasks behind a very simple REST API",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "license": "BSD-3-Clause",
   "main": "dist/cjs/sdk.js",
   "exports": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -303,7 +303,7 @@ class Client {
         'x-sdk-name': 'Web',
         'x-sdk-platform': 'client',
         'x-sdk-language': 'web',
-        'x-sdk-version': '16.0.1',
+        'x-sdk-version': '16.0.2',
         'X-Appwrite-Response-Format': '1.6.0',
     };
 
@@ -589,6 +589,7 @@ class Client {
         let options: RequestInit = {
             method,
             headers,
+            credentials: 'include',
         };
 
         if (method === 'GET') {


### PR DESCRIPTION
Adds `credentials: 'include'` to fetch requests so 3rd party cookies are sent to Appwrite.

Fixes OAuth2 login issues

Related:
* https://github.com/appwrite/sdk-generator/pull/994