### PR TITLE
Fix autocomplete for Databases.createDocument

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -55,8 +55,8 @@ export namespace Models {
         logs: Log[];
     }
     /**
-     * Files List
-     */
+         * Files List
+         */
     export type FileList = {
         /**
          * Total number of files documents that matched your query.
@@ -212,6 +212,11 @@ export namespace Models {
          * Document permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).
          */
         $permissions: string[];
+    }
+    /**
+     * AnyDocument
+     */
+    export interface AnyDocument extends Document {
         [key: string]: any;
     }
     /**
@@ -978,8 +983,8 @@ export namespace Models {
         code: string;
     }
     /**
-     * Language
-     */
+         * Language
+         */
     export type Language = {
         /**
          * Language name.

--- a/src/services/databases.ts
+++ b/src/services/databases.ts
@@ -54,12 +54,12 @@ export class Databases {
      * @param {string} databaseId
      * @param {string} collectionId
      * @param {string} documentId
-     * @param {Omit<Document, keyof Models.Document>} data
+     * @param {Omit<T, keyof Models.Document>} data
      * @param {string[]} permissions
      * @throws {AppwriteException}
-     * @returns {Promise<Document>}
+     * @returns {Promise<T>}
      */
-    async createDocument<Document extends Models.Document>(databaseId: string, collectionId: string, documentId: string, data: Omit<Document, keyof Models.Document>, permissions?: string[]): Promise<Document> {
+    async createDocument<T extends Models.Document = Models.AnyDocument>(databaseId: string, collectionId: string, documentId: string, data: Omit<T, keyof Models.Document>, permissions?: string[]): Promise<T> {
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
         }


### PR DESCRIPTION
Fixes #76

Update `createDocument` method to improve TypeScript autocompletion.

* **src/models.ts**
  - Remove the string index signature from `Models.Document`.
  - Add a new type `AnyDocument` extending `Models.Document` with the string index signature.

* **src/services/databases.ts**
  - Update `createDocument` method to use `T extends Models.Document = Models.AnyDocument`.
  - Update `data` parameter type to `Omit<T, keyof Models.Document>`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/appwrite/sdk-for-web/pull/119?shareId=0a23dde7-39af-4686-9ab4-e3c518ff75fa).